### PR TITLE
Lekka poprawa przycisku od githuba

### DIFF
--- a/index.html
+++ b/index.html
@@ -737,7 +737,7 @@
                     Linexin is built with fully open-sourced code. Fork, modify, or contribute on GitHub.
                 </p>
                 <a href="https://github.com/Petexy/Linexin" target="_blank" rel="noopener noreferrer"
-                    class="inline-flex items-center gap-2 bg-[#24292e] hover:bg-[#2f363d] text-white px-8 py-4 rounded-xl font-bold transition-all duration-300 hover:scale-105 active:scale-95 border border-white/10 shadow-xl"
+                    class="inline-flex items-center gap-2 bg-[#9d4edd]/20 hover:bg-[#9d4edd]/30 text-white px-8 py-4 rounded-xl font-bold transition-all duration-300 hover:scale-105 active:scale-95 border border-[#9d4edd]/40 shadow-[0_0_24px_rgba(157,78,221,0.25)] backdrop-blur-md"
                     data-translate-key="community_button">
                     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                         <path fill-rule="evenodd"


### PR DESCRIPTION
Ogolnie to raczej pierdółka ale osobiście dla mnie obecny przycisk za bardzo odstaje od designu całej strony dlatego tutaj moja propozycja przycisku redirectującego do githuba
<img width="720" height="276" alt="image" src="https://github.com/user-attachments/assets/951f1f9c-81b1-4ce9-ac96-4b9992da193b" />
<img width="697" height="319" alt="image" src="https://github.com/user-attachments/assets/2aec1f8e-c904-4969-8a99-9bb8f88fc535" />
